### PR TITLE
add a validation check that source and destination accounts are different

### DIFF
--- a/dst_backup_vault.tf
+++ b/dst_backup_vault.tf
@@ -2,4 +2,11 @@ resource "aws_backup_vault" "aws_dst_backup_vault" {
   name        = "aws_backup_vault"
   provider    = aws.dst
   kms_key_arn = aws_kms_key.aws_dst_backup_kms_key.arn
+
+  lifecycle {
+    precondition {
+      condition     = data.aws_caller_identity.current.account_id != data.aws_caller_identity.dst_account.account_id
+      error_message = "Destination account ID (${data.aws_caller_identity.dst_account.account_id}) must not match source account ID (${data.aws_caller_identity.current.account_id})"
+    }
+  }
 }


### PR DESCRIPTION
This might prevent testing, but I think it's useful to validate whether the two accounts are distinct.

```
│ Error: Resource precondition failed
│
│   on .terraform/modules/backups/dst_backup_vault.tf line 8, in resource "aws_backup_vault" "aws_dst_backup_vault":
│    8:       condition     = data.aws_caller_identity.current.account_id != data.aws_caller_identity.dst_account.account_id
│     ├────────────────
│     │ data.aws_caller_identity.current.account_id is "1234567890"
│     │ data.aws_caller_identity.dst_account.account_id is "0987654321"
│
│ Destination account ID (1234567890) must not match source account ID (0987654321)
╵
```