### PR TITLE
[DOM-54969] AWS Backup Vault Lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ No modules.
 | [aws_backup_vault.aws_src_backup_vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault) | resource |
 | [aws_backup_vault_lock_configuration.aws_dst_backup_vault_lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_lock_configuration) | resource |
 | [aws_backup_vault_lock_configuration.aws_src_backup_vault_lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_lock_configuration) | resource |
-| [aws_backup_vault_lock_configuration.aws_src_backup_vault_lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_lock_configuration) | resource |
 | [aws_backup_vault_policy.aws_dst_backup_vault_policy_allow_src](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_policy) | resource |
+| [aws_backup_vault_policy.aws_src_backup_vault_policy_allow_dst](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_policy) | resource |
 | [aws_ecr_registry_policy.ecr_registry_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_registry_policy) | resource |
 | [aws_ecr_replication_configuration.ecr_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_replication_configuration) | resource |
 | [aws_iam_role.aws_backup_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ No modules.
 | [aws_backup_selection.aws_backup_selection](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_selection) | resource |
 | [aws_backup_vault.aws_dst_backup_vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault) | resource |
 | [aws_backup_vault.aws_src_backup_vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault) | resource |
+| [aws_backup_vault_lock_configuration.aws_dst_backup_vault_lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_lock_configuration) | resource |
++| [aws_backup_vault_lock_configuration.aws_src_backup_vault_lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_lock_configuration) | resource |
 | [aws_backup_vault_policy.aws_dst_backup_vault_policy_allow_src](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_policy) | resource |
 | [aws_backup_vault_policy.aws_src_backup_vault_policy_allow_dst](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_policy) | resource |
 | [aws_ecr_registry_policy.ecr_registry_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_registry_policy) | resource |

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ No modules.
 | [aws_backup_vault.aws_dst_backup_vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault) | resource |
 | [aws_backup_vault.aws_src_backup_vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault) | resource |
 | [aws_backup_vault_lock_configuration.aws_dst_backup_vault_lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_lock_configuration) | resource |
-+| [aws_backup_vault_lock_configuration.aws_src_backup_vault_lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_lock_configuration) | resource |
+| [aws_backup_vault_lock_configuration.aws_src_backup_vault_lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_lock_configuration) | resource |
+| [aws_backup_vault_lock_configuration.aws_src_backup_vault_lock](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_lock_configuration) | resource |
 | [aws_backup_vault_policy.aws_dst_backup_vault_policy_allow_src](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_policy) | resource |
-| [aws_backup_vault_policy.aws_src_backup_vault_policy_allow_dst](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/backup_vault_policy) | resource |
 | [aws_ecr_registry_policy.ecr_registry_permission](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_registry_policy) | resource |
 | [aws_ecr_replication_configuration.ecr_replication](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_replication_configuration) | resource |
 | [aws_iam_role.aws_backup_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |

--- a/dst_backup_vault.tf
+++ b/dst_backup_vault.tf
@@ -15,7 +15,7 @@ resource "aws_backup_vault_lock_configuration" "aws_dst_backup_vault_lock" {
   backup_vault_name   = aws_backup_vault.aws_dst_backup_vault.name
   provider    = aws.dst
   min_retention_days  = floor(var.delete_after * (1-0.1))
-  max_retention_days  = ceil(var.delete_after * (1+0.1))
+  max_retention_days  = var.delete_after
 }
 
 resource "aws_backup_vault_policy" "aws_dst_backup_vault_policy_allow_src" {

--- a/dst_backup_vault.tf
+++ b/dst_backup_vault.tf
@@ -11,6 +11,13 @@ resource "aws_backup_vault" "aws_dst_backup_vault" {
   }
 }
 
+resource "aws_backup_vault_lock_configuration" "aws_dst_backup_vault_lock" {
+  backup_vault_name   = aws_backup_vault.aws_dst_backup_vault.name
+  provider    = aws.dst
+  min_retention_days  = floor(var.delete_after * (1-0.1))
+  max_retention_days  = ceil(var.delete_after * (1+0.1))
+}
+
 resource "aws_backup_vault_policy" "aws_dst_backup_vault_policy_allow_src" {
   backup_vault_name = aws_backup_vault.aws_dst_backup_vault.name
   provider          = aws.dst

--- a/dst_backup_vault.tf
+++ b/dst_backup_vault.tf
@@ -12,10 +12,10 @@ resource "aws_backup_vault" "aws_dst_backup_vault" {
 }
 
 resource "aws_backup_vault_lock_configuration" "aws_dst_backup_vault_lock" {
-  backup_vault_name   = aws_backup_vault.aws_dst_backup_vault.name
-  provider    = aws.dst
-  min_retention_days  = floor(var.delete_after * (1-0.1))
-  max_retention_days  = var.delete_after
+  backup_vault_name  = aws_backup_vault.aws_dst_backup_vault.name
+  provider           = aws.dst
+  min_retention_days = floor(var.delete_after * (1-0.1))
+  max_retention_days = var.delete_after
 }
 
 resource "aws_backup_vault_policy" "aws_dst_backup_vault_policy_allow_src" {

--- a/dst_backup_vault.tf
+++ b/dst_backup_vault.tf
@@ -14,7 +14,7 @@ resource "aws_backup_vault" "aws_dst_backup_vault" {
 resource "aws_backup_vault_lock_configuration" "aws_dst_backup_vault_lock" {
   backup_vault_name  = aws_backup_vault.aws_dst_backup_vault.name
   provider           = aws.dst
-  min_retention_days = floor(var.delete_after * (1-0.1))
+  min_retention_days = floor(var.delete_after * (1 - 0.1))
   max_retention_days = var.delete_after
 }
 

--- a/src_backup_vault.tf
+++ b/src_backup_vault.tf
@@ -3,6 +3,12 @@ resource "aws_backup_vault" "aws_src_backup_vault" {
   kms_key_arn = aws_kms_key.aws_src_backup_kms_key.arn
 }
 
+resource "aws_backup_vault_lock_configuration" "aws_src_backup_vault_lock" {
+  backup_vault_name   = aws_backup_vault.aws_src_backup_vault.name
+  min_retention_days  = floor(var.delete_after * (1-0.1))
+  max_retention_days  = ceil(var.delete_after * (1+0.1))
+}
+
 resource "aws_backup_vault_policy" "aws_src_backup_vault_policy_allow_dst" {
   backup_vault_name = aws_backup_vault.aws_src_backup_vault.name
   policy            = <<POLICY

--- a/src_backup_vault.tf
+++ b/src_backup_vault.tf
@@ -4,9 +4,9 @@ resource "aws_backup_vault" "aws_src_backup_vault" {
 }
 
 resource "aws_backup_vault_lock_configuration" "aws_src_backup_vault_lock" {
-  backup_vault_name   = aws_backup_vault.aws_src_backup_vault.name
-  min_retention_days  = floor(var.delete_after * (1-0.1))
-  max_retention_days  = var.delete_after
+  backup_vault_name  = aws_backup_vault.aws_src_backup_vault.name
+  min_retention_days = floor(var.delete_after * (1-0.1))
+  max_retention_days = var.delete_after
 }
 
 resource "aws_backup_vault_policy" "aws_src_backup_vault_policy_allow_dst" {

--- a/src_backup_vault.tf
+++ b/src_backup_vault.tf
@@ -5,7 +5,7 @@ resource "aws_backup_vault" "aws_src_backup_vault" {
 
 resource "aws_backup_vault_lock_configuration" "aws_src_backup_vault_lock" {
   backup_vault_name  = aws_backup_vault.aws_src_backup_vault.name
-  min_retention_days = floor(var.delete_after * (1-0.1))
+  min_retention_days = floor(var.delete_after * (1 - 0.1))
   max_retention_days = var.delete_after
 }
 

--- a/src_backup_vault.tf
+++ b/src_backup_vault.tf
@@ -6,7 +6,7 @@ resource "aws_backup_vault" "aws_src_backup_vault" {
 resource "aws_backup_vault_lock_configuration" "aws_src_backup_vault_lock" {
   backup_vault_name   = aws_backup_vault.aws_src_backup_vault.name
   min_retention_days  = floor(var.delete_after * (1-0.1))
-  max_retention_days  = ceil(var.delete_after * (1+0.1))
+  max_retention_days  = var.delete_after
 }
 
 resource "aws_backup_vault_policy" "aws_src_backup_vault_policy_allow_dst" {


### PR DESCRIPTION
**Feature**:  Adding AWS Backup Vault Lock

**Why?**: We want to avoid backups being deleted manually by mistake or because an attacker is deleting our backups 

**Period:** The backup plan retains backup for 35 days, so lock was added to min: 31 days (meaning nobody can delete the backup for the first 31 days) and max 35 (to allow the backup plan for automatic deletion), the values are computed dynamically based on the retention days in the plan

**Type:** There are two types of lock governance and compliance, the mode used here is governance which allows the lock to be removed in the future, when using governance nobody can remove the lock https://docs.aws.amazon.com/aws-backup/latest/devguide/vault-lock.html

**Concerns**: Not sure about the impact of this during decommission, assuming there is a cloud customer trial, after 1 week they say ok I want to destroy the instance, and probably we should remove the lock manually or we need to figure out how to do this from TF.
